### PR TITLE
This should fix server issues...

### DIFF
--- a/Config/app.json
+++ b/Config/app.json
@@ -1,0 +1,4 @@
+{
+	"facebookClientID": "$FACEBOOK_CLIENT_ID",
+	"facebookClientSecret": "$FACEBOOK_CLIENT_SECRET"
+}

--- a/README.md
+++ b/README.md
@@ -21,7 +21,20 @@ In the Valid OAuth redirect URIs box, type in your application's URL, postpended
 
 ### **Add your Client ID / Secret as Environment Variables**
 
-Create a file `Config/secrets/app.json` (this directory is under `.gitignore` and should never be committed  to the repository), with the following content:
+The code reads your Facebook client ID and secret from environment variables, and that mechanism is used on the server as well. Just set the following environment variables prior to running the code:
+
+```shell
+export FACEBOOK_CLIENT_ID="<your facebook app id>"
+export FACEBOOK_CLIENT_SECRET="<your facebook app secret>"
+```
+
+This is also possible in Xcode under `Edit Scheme > Arguments > Environment Variables`.
+
+#### Alternative
+
+Setting the environment variables on macOS might not work under all circumstances. Creating a secrets file will.
+
+Create the file `Config/secrets/app.json` (this directory is under `.gitignore` and should never be committed  to the repository), with the following content:
 
 ```json
 {

--- a/Sources/App/Auth/Request+VaporAuth.swift
+++ b/Sources/App/Auth/Request+VaporAuth.swift
@@ -11,11 +11,6 @@ import Turnstile
 
 extension Request {
 
-	// Base URL returns the hostname, scheme, and port in a URL string form.
-	var baseURL: String {
-		return uri.scheme + "://" + uri.host + (uri.port == nil ? "" : ":\(uri.port!)")
-	}
-
 	// Exposes the Turnstile subject, as Vapor has a facade on it. 
 	var subject: Subject {
 		return storage["subject"] as! Subject

--- a/Sources/App/Request+ProxyHandling.swift
+++ b/Sources/App/Request+ProxyHandling.swift
@@ -1,0 +1,23 @@
+//
+//  Request+ProxyHandling.swift
+//  theClocker
+//
+//  Created by Goran Blažič on 02/01/2017.
+//
+//
+
+import HTTP
+import Turnstile
+
+// This pretty much expects a header named X-base-URL with value in the form "https://host.domain.com"
+
+extension Request {
+
+	var baseURL: String {
+		guard let proxyBase = headers["X-base-URL"] else {
+			return uri.scheme + "://" + uri.host + (uri.port == nil ? "" : ":\(uri.port!)")
+		}
+		return proxyBase
+	}
+
+}


### PR DESCRIPTION
The problem was that vapor always sees the local hostname as baseURL,
which messes with things if you put it behind a proxy. This has been
fixed, if the proxy provides a X-base-URL header to the vapor app. This
header must contain the baseURL to use for the app
(https://clocker.goranche.net)
This can be achieved on nginx with the following directive:
  proxy_set_header X-base-URL $scheme://$host;