### PR TITLE
Changed the instantiation code for the Droplet

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,17 +1,17 @@
 import PackageDescription
 
 let package = Package(
-    name: "theClocker",
-    dependencies: [
-        .Package(url: "https://github.com/vapor/vapor.git", majorVersion: 1, minor: 3)
-    ],
-    exclude: [
-        "Config",
-        "Database",
-        "Localization",
-        "Public",
-        "Resources",
-        "Tests",
-    ]
+	name: "theClocker",
+	dependencies: [
+		.Package(url: "https://github.com/vapor/vapor.git", majorVersion: 1, minor: 3),
+		.Package(url: "https://github.com/sfaxon/vapor-memory-provider.git", majorVersion: 1)
+	],
+	exclude: [
+		"Config",
+		"Database",
+		"Localization",
+		"Public",
+		"Resources",
+		"Tests",
+	]
 )
-


### PR DESCRIPTION
The previous code used a deprecated constructor method. A memory DB
provider needed to be added, but this now causes a log entry about a
deprecated vapor API thingy... will deal with that when the time comes.
If the memory DB provider gets updated this log entry should disappear,
though... hopefully 😅