### PR TITLE
Another "fix" for the workdir issue.

### DIFF
--- a/Sources/App/main.swift
+++ b/Sources/App/main.swift
@@ -9,7 +9,7 @@ import TurnstileWeb
 import Fluent
 import Foundation
 
-let drop = Droplet(workDir: "./")
+let drop = Droplet(workDir: nil)
 
 try drop.addProvider(VaporSQLite.Provider.self)
 


### PR DESCRIPTION
The previous fix worked on the server, but not for development in Xcode.
Not sure how to fix this properly yet, so making it so it works for
development and allows for relatively easy fix on server seems like the
right thing to do for now.